### PR TITLE
add author.url of article structured data

### DIFF
--- a/inc/seo/class-structured-data.php
+++ b/inc/seo/class-structured-data.php
@@ -129,6 +129,7 @@ class Structured_Data {
 			$data['author']           = [
 				'@type' => 'Person',
 				'name'  => get_the_author_meta( 'display_name', $post->post_author ),
+				'url'   => get_author_posts_url( $post->post_author ),
 			];
 			$data['datePublished']    = get_the_date( DATE_ATOM, $post->ID );
 			$data['dateModified']     = get_post_modified_time( DATE_ATOM, false, $post->ID );


### PR DESCRIPTION
## 概要
構造化データに author.url プロパティを追加

## 理由
Googleリッチリザルトテストで推奨項目がないため警告が発生していた