### PR TITLE
get_template_part() に渡されている$name引数を空配列から空文字列に変更

### DIFF
--- a/inc/breadcrumbs/class-breadcrumbs.php
+++ b/inc/breadcrumbs/class-breadcrumbs.php
@@ -130,7 +130,7 @@ class Breadcrumbs {
 		ob_start();
 		Template::get_template_part(
 			'template-parts/parts/breadcrumbs',
-			[],
+			'',
 			[ 'breadcrumbs' => $this->get_breadcrumbs() ]
 		);
 		echo ob_get_clean();


### PR DESCRIPTION
# 概要
get_template_part() に渡されている$name引数を空配列から空文字列に変更

# 理由
$name を使用したコーディングを行う際にエラーの原因になるため