### PR TITLE
ブロックエディターの色とフォントサイズ設定を調整

### DIFF
--- a/tests/test-block-editor-assets.php
+++ b/tests/test-block-editor-assets.php
@@ -44,6 +44,19 @@ class BlockEditorAssetsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * WordPress標準のカラーパレットが無効であることを確認.
+	 */
+	public function test_default_color_palette_is_disabled() {
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		$default_palette_enabled = wp_get_global_settings( [ 'color', 'defaultPalette' ] );
+		$theme_palette           = wp_get_global_settings( [ 'color', 'palette', 'theme' ] );
+
+		$this->assertFalse( $default_palette_enabled );
+		$this->assertNotEmpty( $theme_palette );
+	}
+
+	/**
 	 * 編集コンテンツへフォント設定を追加できることを確認.
 	 */
 	public function test_enqueue_font_settings_for_editor_content() {

--- a/theme.json
+++ b/theme.json
@@ -9,7 +9,7 @@
 			"wideSize": "1200px"
 		},
 		"color": {
-			"defaultPalette": true,
+			"defaultPalette": false,
 			"palette": [
 				{
 					"color": "#07689f",
@@ -521,12 +521,12 @@
 				},
 				{
 					"fluid": {
-						"min": "0.875rem",
+						"min": "1rem",
 						"max": "1.125rem"
 					},
-					"size": "1.139rem",
-					"name": "18px-14px",
-					"slug": "ys-18-14"
+					"size": "1.141rem",
+					"name": "18px-16px",
+					"slug": "ys-18-16"
 				},
 				{
 					"fluid": false,


### PR DESCRIPTION
## 概要

- ブロック設定の色選択でWordPress標準の「デフォルト」パレットを表示しないように変更
- 流体フォントサイズの定義を14px〜18pxから16px〜18pxへ変更
- 標準カラーパレットの無効化を確認する回帰テストを追加

## 検証

- `npm run test:php -- --filter test_default_color_palette_is_disabled`
- `composer phpcs -- tests/test-block-editor-assets.php`
- `theme.json`のJSON解析と設定値確認
- `git diff --check`

## 補足

PHPCSは成功していますが、依存ライブラリのPHPCSUtilsからPHPの非推奨警告が表示されます。

全PHPテストは今回の変更と無関係な既存箇所で10エラー・6失敗があるため、追加した回帰テストを個別実行して成功を確認しています。